### PR TITLE
VIPTT-12: fix ecr depends

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -167,8 +167,7 @@ steps:
         <<: *include_default_and_feature_branches
       event: [push, pull_request]
     depends_on:
-      - linting
-      - unit_tests
+      - build_image
 
   # Trivy Security Scannner for scanning nodejs packages in Yarn
   - name: scan_node_packages


### PR DESCRIPTION
## What? 
feature/VIPTT-12-fix-ecr-depends
- change image_to_ecr depends to build_image only

## Why? 
image_to_ecr not always completing
possible race condition
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [X] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [X] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
