### PR TITLE
VIPTT-19 Add were you in the uk page

### DIFF
--- a/apps/viptt/translations/src/en/journey.json
+++ b/apps/viptt/translations/src/en/journey.json
@@ -1,4 +1,4 @@
 {
-  "header": "HOF Boilerplate",
+  "header": "Check when you will get your visa decision",
   "phase": "beta"
 }

--- a/apps/viptt/translations/src/en/pages.json
+++ b/apps/viptt/translations/src/en/pages.json
@@ -1,8 +1,4 @@
 {
-  "start": {
-    "header": "Welcome to the HOF boilerplate form",
-    "paragraph-1": "This form is contains the most simple steps, this static page, a name input step, and a confirmation step"
-  },
   "confirm": {
     "header": "Check your answers",
     "submit-warning": "Once you have submitted your application, you will not be able to adjust it. Please check it is correct.",

--- a/apps/viptt/translations/src/en/validation.json
+++ b/apps/viptt/translations/src/en/validation.json
@@ -1,0 +1,5 @@
+{
+  "were-you-in-uk": {
+    "required": "Select yes or no"
+  }
+}


### PR DESCRIPTION
## What? 
Add the "Were you in the UK when you applied for your visa" page

## Why? 
Business requirement for Vis Processing Times Tool:
[VIPTT-19](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-19)

## How? 
Added page & translations

## Testing?
No tests as there is no bespoke functionality (basic functionality is tested by framework)

## Screenshots (optional)
<img width="816" alt="VIPTT-19" src="https://github.com/user-attachments/assets/28396882-2f09-42fb-b039-86e495ead1b9" />
<img width="835" alt="VIPTT-19-Error" src="https://github.com/user-attachments/assets/fd43d8a0-d0f1-44fb-ab8c-fc43b4e4ce33" />

## Anything Else? (optional)
Note: Some of the changes for this were already done in the skeleton setup task.

## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
