### PR TITLE
Viptt 31 logic for calculating sla dates

### DIFF
--- a/apps/viptt/behaviours/check-sla-redirect.js
+++ b/apps/viptt/behaviours/check-sla-redirect.js
@@ -1,0 +1,50 @@
+const SlaCalculator = require('../models/sla-calculator');
+const BankHolidays = require('../models/bank-holidays');
+const ServiceAgreements = require('../models/service-agreements');
+/**
+ * Check if the user's expected visa reply date is within SLA
+ * and redirect to correct page if this is true.
+ */
+module.exports = superclass =>
+  class extends superclass {
+    async successHandler(req, res, next) {
+      // Bank Holiday model
+      this._bankHolidays = new BankHolidays();
+      await this._bankHolidays.loadBankHolidays();
+
+      // SLA model
+      this._serviceAgreements = new ServiceAgreements();
+
+      // Sla calculation helper
+      this._slaCalculator = new SlaCalculator(this._bankHolidays);
+
+      // Get the user's reason for applying depending on
+      // whether they were inside or outside UK.
+      const insideUK = req.sessionModel.get('were-you-in-uk') === 'yes';
+      const reasonForApplying = insideUK ?
+        req.sessionModel.get('why-did-you-apply-inside') :
+        req.sessionModel.get('why-did-you-apply-outside');
+
+      // Retrieve the correct sla data
+      const slaData = this._serviceAgreements.getSLAData(reasonForApplying, insideUK);
+
+      // Get the date that user submitted verified their identity.
+      const verificationDate = req.sessionModel.get('identity-verification-date');
+
+      // Calculate the estimated date by which we should have received a reply
+      const estimatedReplyDate = this._slaCalculator.calculateReplyEstimate(
+        verificationDate,
+        slaData.days
+      );
+
+      // Check if reply is still within the SLA timeline
+      const insideSLA = this._slaCalculator.isWithinEstimate(estimatedReplyDate);
+
+      // Redirect if within SLA
+      if (insideSLA) {
+        return res.redirect(`${req.baseUrl}/outcome-inside`);
+      }
+
+      return super.successHandler(req, res, next);
+    }
+  };

--- a/apps/viptt/data/bank_hols_data.json
+++ b/apps/viptt/data/bank_hols_data.json
@@ -1,0 +1,1781 @@
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2019"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 April 2019"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "22 April 2019"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2019"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2019"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 August 2019"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2019"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2019"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2020"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "10 April 2020"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "13 April 2020"
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2020"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2020"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 August 2020"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2020"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2020"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2021"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "2 April 2021"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 April 2021"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2021"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2021"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 August 2021"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2021"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2021"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "3 January 2022"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "15 April 2022"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "18 April 2022"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 May 2022"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 June 2022"
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 June 2022"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 August 2022"
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 September 2022"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2022"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2022"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "2 January 2023"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "7 April 2023"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "10 April 2023"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 May 2023"
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2023"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 May 2023"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "28 August 2023"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2023"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "29 March 2024"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 April 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 August 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "18 April 2025"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "21 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 May 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 August 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2025"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2026"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "3 April 2026"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2026-04-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 April 2026"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "4 May 2026"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2026"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 August 2026"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2026"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2026"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2027-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2027"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2027-03-26",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "26 March 2027"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2027-03-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 March 2027"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2027-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2027"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2027-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2027"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2027-08-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 August 2027"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2027-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2027"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2027-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2027"
+      }
+    ]
+  },
+  "scotland": {
+    "division": "scotland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2019"
+      },
+      {
+        "title": "2nd January",
+        "date": "2019-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 January 2019"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 April 2019"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2019"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2019"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 August 2019"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2019-12-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "2 December 2019"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2019"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2019"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2020"
+      },
+      {
+        "title": "2nd January",
+        "date": "2020-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 January 2020"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "10 April 2020"
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2020"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2020"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 August 2020"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2020-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2020"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2020"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2020"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2021"
+      },
+      {
+        "title": "2nd January",
+        "date": "2021-01-04",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "4 January 2021"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "2 April 2021"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2021"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2021"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 August 2021"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2021-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2021"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2021"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2021"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "3 January 2022"
+      },
+      {
+        "title": "2nd January",
+        "date": "2022-01-04",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "4 January 2022"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "15 April 2022"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 May 2022"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 June 2022"
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 June 2022"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 August 2022"
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 September 2022"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2022-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2022"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2022"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2022"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "2 January 2023"
+      },
+      {
+        "title": "2nd January",
+        "date": "2023-01-03",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "3 January 2023"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "7 April 2023"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 May 2023"
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2023"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 May 2023"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-07",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "7 August 2023"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2023-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2023"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2023"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2024"
+      },
+      {
+        "title": "2nd January",
+        "date": "2024-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 January 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "29 March 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 August 2024"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2024-12-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "2 December 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2025"
+      },
+      {
+        "title": "2nd January",
+        "date": "2025-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 January 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "18 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 May 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-04",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "4 August 2025"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2025-12-01",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "1 December 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2025"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2026"
+      },
+      {
+        "title": "2nd January",
+        "date": "2026-01-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 January 2026"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "3 April 2026"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "4 May 2026"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2026"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 August 2026"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2026-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2026"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2026"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2026"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2027-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2027"
+      },
+      {
+        "title": "2nd January",
+        "date": "2027-01-04",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "4 January 2027"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2027-03-26",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "26 March 2027"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2027-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2027"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2027-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2027"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2027-08-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 August 2027"
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2027-11-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 November 2027"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2027-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2027"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2027-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2027"
+      }
+    ]
+  },
+  "northern-ireland": {
+    "division": "northern-ireland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2019"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2019-03-18",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "18 March 2019"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 April 2019"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "22 April 2019"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2019"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2019"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2019-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2019"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 August 2019"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2019"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2019"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2020"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2020-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2020"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "10 April 2020"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "13 April 2020"
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2020"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2020"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2020-07-13",
+        "notes": "Substitute day",
+        "bunting": false,
+        "formattedDate": "13 July 2020"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 August 2020"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2020"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2020"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2021"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2021-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2021"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "2 April 2021"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 April 2021"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2021"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2021"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2021-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2021"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 August 2021"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2021"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2021"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "3 January 2022"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2022-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2022"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "15 April 2022"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "18 April 2022"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 May 2022"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "2 June 2022"
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 June 2022"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2022-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2022"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 August 2022"
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "19 September 2022"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2022"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2022"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "2 January 2023"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2023-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2023"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "7 April 2023"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "10 April 2023"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 May 2023"
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "8 May 2023"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 May 2023"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2023-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2023"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "28 August 2023"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2023"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2023"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2024"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2024-03-18",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "18 March 2024"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "29 March 2024"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 April 2024"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 May 2024"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "27 May 2024"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2024-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2024"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 August 2024"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2024"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2024"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2025"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2025-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2025"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "18 April 2025"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "21 April 2025"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "5 May 2025"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 May 2025"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2025-07-14",
+        "notes": "Substitute day",
+        "bunting": false,
+        "formattedDate": "14 July 2025"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 August 2025"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2025"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "26 December 2025"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2026-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2026"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2026-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2026"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2026-04-03",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "3 April 2026"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2026-04-06",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "6 April 2026"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2026-05-04",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "4 May 2026"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2026-05-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 May 2026"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2026-07-13",
+        "notes": "Substitute day",
+        "bunting": false,
+        "formattedDate": "13 July 2026"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2026-08-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 August 2026"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2026-12-25",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "25 December 2026"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2026-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2026"
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2027-01-01",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "1 January 2027"
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2027-03-17",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "17 March 2027"
+      },
+      {
+        "title": "Good Friday",
+        "date": "2027-03-26",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "26 March 2027"
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2027-03-29",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "29 March 2027"
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2027-05-03",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "3 May 2027"
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2027-05-31",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "31 May 2027"
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2027-07-12",
+        "notes": "",
+        "bunting": false,
+        "formattedDate": "12 July 2027"
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2027-08-30",
+        "notes": "",
+        "bunting": true,
+        "formattedDate": "30 August 2027"
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2027-12-27",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "27 December 2027"
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2027-12-28",
+        "notes": "Substitute day",
+        "bunting": true,
+        "formattedDate": "28 December 2027"
+      }
+    ]
+  }
+}

--- a/apps/viptt/data/bank_hols_data.json
+++ b/apps/viptt/data/bank_hols_data.json
@@ -6,526 +6,451 @@
         "title": "New Year’s Day",
         "date": "2019-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2019"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2019-04-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 April 2019"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2019-04-22",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "22 April 2019"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2019-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2019"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2019-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2019"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2019-08-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 August 2019"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2019-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2019"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2019-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2019"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2020-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2020"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2020-04-10",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "10 April 2020"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2020-04-13",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "13 April 2020"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday (VE day)",
         "date": "2020-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2020"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2020-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2020"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2020-08-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 August 2020"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2020-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2020"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2020-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2020"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2021-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2021"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2021-04-02",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "2 April 2021"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2021-04-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 April 2021"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2021-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2021"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2021-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2021"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2021-08-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 August 2021"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2021-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2021"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2021-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2021"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2022-01-03",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "3 January 2022"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2022-04-15",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "15 April 2022"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2022-04-18",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "18 April 2022"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2022-05-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 May 2022"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2022-06-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 June 2022"
+        "bunting": true
       },
       {
         "title": "Platinum Jubilee bank holiday",
         "date": "2022-06-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 June 2022"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2022-08-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 August 2022"
+        "bunting": true
       },
       {
         "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
         "date": "2022-09-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 September 2022"
+        "bunting": false
       },
       {
         "title": "Boxing Day",
         "date": "2022-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2022"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2022-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2022"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2023-01-02",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "2 January 2023"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2023-04-07",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "7 April 2023"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2023-04-10",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "10 April 2023"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2023-05-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 May 2023"
+        "bunting": true
       },
       {
         "title": "Bank holiday for the coronation of King Charles III",
         "date": "2023-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2023"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 May 2023"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2023-08-28",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "28 August 2023"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2023-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2023"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2023"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2024-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2024"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2024-03-29",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "29 March 2024"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2024-04-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 April 2024"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2024-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2024"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2024-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2024"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2024-08-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 August 2024"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2024-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2024"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2024-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2024"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2025-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2025"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2025-04-18",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "18 April 2025"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2025-04-21",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "21 April 2025"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2025-05-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 May 2025"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2025-05-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 May 2025"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2025-08-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 August 2025"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2025-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2025"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2025-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2025"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2026-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2026"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2026-04-03",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "3 April 2026"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2026-04-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 April 2026"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2026-05-04",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "4 May 2026"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2026-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2026"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2026-08-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 August 2026"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2026-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2026"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2026-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2026"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2027-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2027"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2027-03-26",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "26 March 2027"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2027-03-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 March 2027"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2027-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2027"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2027-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2027"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2027-08-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 August 2027"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2027-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2027"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2027-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2027"
+        "bunting": true
       }
     ]
   },
@@ -536,589 +461,505 @@
         "title": "New Year’s Day",
         "date": "2019-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2019"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2019-01-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 January 2019"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2019-04-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 April 2019"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2019-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2019"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2019-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2019"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2019-08-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 August 2019"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2019-12-02",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "2 December 2019"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2019-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2019"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2019-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2019"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2020-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2020"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2020-01-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 January 2020"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2020-04-10",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "10 April 2020"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday (VE day)",
         "date": "2020-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2020"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2020-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2020"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2020-08-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 August 2020"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2020-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2020"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2020-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2020"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2020-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2020"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2021-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2021"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2021-01-04",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "4 January 2021"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2021-04-02",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "2 April 2021"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2021-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2021"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2021-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2021"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2021-08-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 August 2021"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2021-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2021"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2021-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2021"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2021-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2021"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2022-01-03",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "3 January 2022"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2022-01-04",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "4 January 2022"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2022-04-15",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "15 April 2022"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2022-05-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 May 2022"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2022-06-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 June 2022"
+        "bunting": true
       },
       {
         "title": "Platinum Jubilee bank holiday",
         "date": "2022-06-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 June 2022"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2022-08-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 August 2022"
+        "bunting": true
       },
       {
         "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
         "date": "2022-09-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 September 2022"
+        "bunting": false
       },
       {
         "title": "St Andrew’s Day",
         "date": "2022-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2022"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2022-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2022"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2022-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2022"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2023-01-02",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "2 January 2023"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2023-01-03",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "3 January 2023"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2023-04-07",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "7 April 2023"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2023-05-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 May 2023"
+        "bunting": true
       },
       {
         "title": "Bank holiday for the coronation of King Charles III",
         "date": "2023-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2023"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 May 2023"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2023-08-07",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "7 August 2023"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2023-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2023"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2023-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2023"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2023"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2024-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2024"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2024-01-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 January 2024"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2024-03-29",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "29 March 2024"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2024-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2024"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2024-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2024"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2024-08-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 August 2024"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2024-12-02",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "2 December 2024"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2024-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2024"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2024-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2024"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2025-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2025"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2025-01-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 January 2025"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2025-04-18",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "18 April 2025"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2025-05-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 May 2025"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2025-05-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 May 2025"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2025-08-04",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "4 August 2025"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2025-12-01",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "1 December 2025"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2025-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2025"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2025-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2025"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2026-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2026"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2026-01-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 January 2026"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2026-04-03",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "3 April 2026"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2026-05-04",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "4 May 2026"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2026-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2026"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2026-08-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 August 2026"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2026-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2026"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2026-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2026"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2026-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2026"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2027-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2027"
+        "bunting": true
       },
       {
         "title": "2nd January",
         "date": "2027-01-04",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "4 January 2027"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2027-03-26",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "26 March 2027"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday",
         "date": "2027-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2027"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2027-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2027"
+        "bunting": true
       },
       {
         "title": "Summer bank holiday",
         "date": "2027-08-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 August 2027"
+        "bunting": true
       },
       {
         "title": "St Andrew’s Day",
         "date": "2027-11-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 November 2027"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2027-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2027"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2027-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2027"
+        "bunting": true
       }
     ]
   },
@@ -1129,652 +970,559 @@
         "title": "New Year’s Day",
         "date": "2019-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2019"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2019-03-18",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "18 March 2019"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2019-04-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 April 2019"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2019-04-22",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "22 April 2019"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2019-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2019"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2019-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2019"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2019-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2019"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2019-08-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 August 2019"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2019-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2019"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2019-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2019"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2020-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2020"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2020-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2020"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2020-04-10",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "10 April 2020"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2020-04-13",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "13 April 2020"
+        "bunting": false
       },
       {
         "title": "Early May bank holiday (VE day)",
         "date": "2020-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2020"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2020-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2020"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2020-07-13",
         "notes": "Substitute day",
-        "bunting": false,
-        "formattedDate": "13 July 2020"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2020-08-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 August 2020"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2020-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2020"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2020-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2020"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2021-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2021"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2021-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2021"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2021-04-02",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "2 April 2021"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2021-04-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 April 2021"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2021-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2021"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2021-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2021"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2021-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2021"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2021-08-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 August 2021"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2021-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2021"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2021-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2021"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2022-01-03",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "3 January 2022"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2022-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2022"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2022-04-15",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "15 April 2022"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2022-04-18",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "18 April 2022"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2022-05-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 May 2022"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2022-06-02",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "2 June 2022"
+        "bunting": true
       },
       {
         "title": "Platinum Jubilee bank holiday",
         "date": "2022-06-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 June 2022"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2022-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2022"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2022-08-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 August 2022"
+        "bunting": true
       },
       {
         "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
         "date": "2022-09-19",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "19 September 2022"
+        "bunting": false
       },
       {
         "title": "Boxing Day",
         "date": "2022-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2022"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2022-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2022"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2023-01-02",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "2 January 2023"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2023-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2023"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2023-04-07",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "7 April 2023"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2023-04-10",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "10 April 2023"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2023-05-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 May 2023"
+        "bunting": true
       },
       {
         "title": "Bank holiday for the coronation of King Charles III",
         "date": "2023-05-08",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "8 May 2023"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 May 2023"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2023-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2023"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2023-08-28",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "28 August 2023"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2023-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2023"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2023"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2024-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2024"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2024-03-18",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "18 March 2024"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2024-03-29",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "29 March 2024"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2024-04-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 April 2024"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2024-05-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 May 2024"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2024-05-27",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "27 May 2024"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2024-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2024"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2024-08-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 August 2024"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2024-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2024"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2024-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2024"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2025-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2025"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2025-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2025"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2025-04-18",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "18 April 2025"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2025-04-21",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "21 April 2025"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2025-05-05",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "5 May 2025"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2025-05-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 May 2025"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2025-07-14",
         "notes": "Substitute day",
-        "bunting": false,
-        "formattedDate": "14 July 2025"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2025-08-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 August 2025"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2025-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2025"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2025-12-26",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "26 December 2025"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2026-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2026"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2026-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2026"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2026-04-03",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "3 April 2026"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2026-04-06",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "6 April 2026"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2026-05-04",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "4 May 2026"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2026-05-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 May 2026"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2026-07-13",
         "notes": "Substitute day",
-        "bunting": false,
-        "formattedDate": "13 July 2026"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2026-08-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 August 2026"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2026-12-25",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "25 December 2026"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2026-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2026"
+        "bunting": true
       },
       {
         "title": "New Year’s Day",
         "date": "2027-01-01",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "1 January 2027"
+        "bunting": true
       },
       {
         "title": "St Patrick’s Day",
         "date": "2027-03-17",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "17 March 2027"
+        "bunting": true
       },
       {
         "title": "Good Friday",
         "date": "2027-03-26",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "26 March 2027"
+        "bunting": false
       },
       {
         "title": "Easter Monday",
         "date": "2027-03-29",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "29 March 2027"
+        "bunting": true
       },
       {
         "title": "Early May bank holiday",
         "date": "2027-05-03",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "3 May 2027"
+        "bunting": true
       },
       {
         "title": "Spring bank holiday",
         "date": "2027-05-31",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "31 May 2027"
+        "bunting": true
       },
       {
         "title": "Battle of the Boyne (Orangemen’s Day)",
         "date": "2027-07-12",
         "notes": "",
-        "bunting": false,
-        "formattedDate": "12 July 2027"
+        "bunting": false
       },
       {
         "title": "Summer bank holiday",
         "date": "2027-08-30",
         "notes": "",
-        "bunting": true,
-        "formattedDate": "30 August 2027"
+        "bunting": true
       },
       {
         "title": "Christmas Day",
         "date": "2027-12-27",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "27 December 2027"
+        "bunting": true
       },
       {
         "title": "Boxing Day",
         "date": "2027-12-28",
         "notes": "Substitute day",
-        "bunting": true,
-        "formattedDate": "28 December 2027"
+        "bunting": true
       }
     ]
   }

--- a/apps/viptt/data/sla_data.json
+++ b/apps/viptt/data/sla_data.json
@@ -1,0 +1,64 @@
+{
+  "default": {
+    "inside-uk": {
+      "study-exam-or-school-exchange": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "visit-as-tourist-or-see-family": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "work-or-business-related-meetings": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "work-visa-health-and-care": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "lecture-research-or-academic-placement": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "bno-with-connections-to-hk": {
+        "weeks": "12",
+        "days": "60"
+      }
+    },
+    "outside-uk": {
+      "study-exam-or-school-exchange": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "visit-as-tourist-or-see-family": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "work-or-business-related-meetings": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "lecture-research-or-academic-placement": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "get-married-or-civil-partnership": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "have-medical-treatment": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "travel-through-uk-to-another-country": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "bno-with-connections-to-hk": {
+        "weeks": "12",
+        "days": "60"
+      }
+    }
+  }
+}

--- a/apps/viptt/fields/index.js
+++ b/apps/viptt/fields/index.js
@@ -52,9 +52,7 @@ module.exports = {
   },
   'identity-verification-date': dateComponent('identity-verification-date', {
     mixin: 'input-date',
-    validate: ['required', 'before'],
-    legend: {
-      className: 'govuk-fieldset__legend--m'
-    }
+    isPageHeading: true,
+    validate: ['required', 'before']
   })
 };

--- a/apps/viptt/fields/index.js
+++ b/apps/viptt/fields/index.js
@@ -1,3 +1,5 @@
+const dateComponent = require('hof').components.date;
+
 module.exports = {
   'were-you-in-uk': {
     mixin: 'radio-group',
@@ -48,13 +50,11 @@ module.exports = {
       'no'
     ]
   },
-  'temporary-field': {
-    mixin: 'radio-group',
-    isPageHeading: true,
-    validate: ['required'],
-    options: [
-      'yes',
-      'no'
-    ]
-  }
+  'identity-verification-date': dateComponent('identity-verification-date', {
+    mixin: 'input-date',
+    validate: ['required', 'before'],
+    legend: {
+      className: 'govuk-fieldset__legend--m'
+    }
+  })
 };

--- a/apps/viptt/index.js
+++ b/apps/viptt/index.js
@@ -1,5 +1,6 @@
 const hof = require('hof');
 const summary = hof.components.summary;
+const checkSlaRedirect = require('./behaviours/check-sla-redirect');
 
 module.exports = {
   name: 'VIPTT',
@@ -68,30 +69,17 @@ module.exports = {
     '/out-of-scope': {
     },
     '/biometrics': {
-      fields: ['temporary-field'],
-      forks: [
-        {
-          target: '/outcome-inside',
-          condition: {
-            field: 'temporary-field',
-            value: 'yes'
-          }
-        },
-        {
-          target: '/outcome-outside',
-          condition: {
-            field: 'temporary-field',
-            value: 'no'
-          }
-        }
-      ],
-      next: '/outcome-inside'
+      fields: ['identity-verification-date'],
+      behaviours: [checkSlaRedirect],
+      next: '/outcome-outside'
     },
     '/outcome-inside': {
       behaviours: ['complete', summary]
     },
     '/outcome-outside': {
       behaviours: ['complete', summary]
-    }
+    },
+    '/session-timeout': {},
+    '/exit': {}
   }
 };

--- a/apps/viptt/models/bank-holidays.js
+++ b/apps/viptt/models/bank-holidays.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const _ = require('lodash');
+const Model = require('hof').model;
+const fs = require('fs').promises;
+const moment = require('moment');
+const config = require('../../../config');
+const inputDateFormat = config.inputDateFormat;
+const displayDateFormat = config.displayDateFormat;
+const bankHolidaysApi = config.bankHolidaysApi;
+
+const BH_FILE_PATH = '/../data/bank_hols_data.json';
+const DEFAULT_COUNTRY = 'england-and-wales';
+
+/**
+ * Bank Holidays data model
+ * This model is responsible for loading and saving bank holiday data
+ */
+module.exports = class BankHolidays {
+  /**
+   * @param {string} country
+   */
+  constructor(country) {
+    // Can use bank holiday data from England and Wales, Scotland and Northern Ireland
+    // However the requirements are for us to only use England and Wales bank hols for now
+    this._country = country || DEFAULT_COUNTRY;
+  }
+
+  /**
+   * Return a date formatted according to the display date format
+   * @param {string} date
+   * @returns {moment}
+   */
+  formattedDate(date) {
+    return moment(date, inputDateFormat).format(displayDateFormat);
+  }
+
+  /**
+   * Update the bank holiday data with formatted dates
+   * We can use these to display the dates in a more user-friendly format
+   * @param {Object} data
+   */
+  addFormattedDates(data) {
+    Object.entries(data).forEach(val => _.map(data[val[0]].events, day => {
+      day.formattedDate = this.formattedDate(day.date);
+      return day;
+    }));
+  }
+
+  /**
+   * Check if the bank holiday data is valid
+   * @param {Object} data
+   * @returns
+   */
+  checkDataIsValid(data) {
+    return !!_.get(data, `[${this._country}].events`);
+  }
+
+  /**
+   * Load the bank holidays data from the file
+   * @returns {Promise}
+   */
+  async loadBankHolidays() {
+    try {
+      // Loading bank holidays is required here to ensure a fresh read of the file each time. This is due
+      // to the fact the running service actively updates it through periodic automated API calls.
+      const fileName = `${__dirname}${BH_FILE_PATH}`;
+      const rawDates = await fs.readFile(fileName, { encoding: 'utf8' }, err => {
+        if (err) {
+          return Promise.reject(new Error(`Failed to load Bank Holidays data from file:
+            ${err}`));
+        }
+        return err;
+      });
+
+      const dates = JSON.parse(rawDates);
+
+      // Check if data loaded from file is correct
+      if (!this.checkDataIsValid(dates)) {
+        return Promise.reject(new Error('Bank Holidays data from file is invalid'));
+      }
+
+      const allDatesByCountry = dates[this._country].events;
+      this._bankHolidayData = _.sortBy(allDatesByCountry, 'date');
+
+      // return this._bankHolidayData;
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(new Error(`Bank Holidays File Read Failure: ${e.message}`));
+    }
+  }
+
+  /**
+   * Fetch back holiday data from api and save it to a file
+   * @returns {Promise}
+   */
+  async saveBankHolidays() {
+    try {
+      const model = new Model();
+      const params = {
+        url: bankHolidaysApi,
+        method: 'GET'
+      };
+
+      const data = await model.fetch(params);
+
+      // Check if we successfully fetched data from API
+      if (!this.checkDataIsValid(data)) {
+        return Promise.reject(new Error('Failed to retrieve data from Bank Holidays API'));
+      }
+      this.addFormattedDates(data);
+
+      const fileName = `${__dirname}${BH_FILE_PATH}`;
+      return await fs.writeFile(fileName, JSON.stringify(data, null, 2), { flag: 'w+' });
+    } catch (error) {
+      return Promise.reject(new Error(`Error fetching bank holidays:  ${error}`));
+    }
+  }
+
+  /**
+   * Check if the date is a bank holiday
+   * @param {moment} date
+   * @returns {boolean}
+   */
+  isBankHoliday(date) {
+    const formattedDate = date.format(inputDateFormat);
+    return !!_.find(this._bankHolidayData, { date: formattedDate });
+  }
+
+  /**
+   * Check if the date is on a weekend
+   * @param {moment} date
+   * @returns {boolean}
+   */
+  isWeekend(date) {
+    const day = new Date(date).getDay();
+    return (day === 6) || (day === 0);
+  }
+
+  /**
+   * Check if the date is a working day
+   * @param {moment} date
+   * @returns {boolean}
+   */
+  isWorkingDay(date) {
+    return !this.isWeekend(date) && !this.isBankHoliday(date);
+  }
+};

--- a/apps/viptt/models/bank-holidays.js
+++ b/apps/viptt/models/bank-holidays.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const Model = require('hof').model;
-const fs = require('fs').promises;
+const fs = require('fs/promises');
 const moment = require('moment');
 const config = require('../../../config');
 const inputDateFormat = config.inputDateFormat;
@@ -24,27 +24,6 @@ module.exports = class BankHolidays {
     // Can use bank holiday data from England and Wales, Scotland and Northern Ireland
     // However the requirements are for us to only use England and Wales bank hols for now
     this._country = country || DEFAULT_COUNTRY;
-  }
-
-  /**
-   * Return a date formatted according to the display date format
-   * @param {string} date
-   * @returns {moment}
-   */
-  formattedDate(date) {
-    return moment(date, inputDateFormat).format(displayDateFormat);
-  }
-
-  /**
-   * Update the bank holiday data with formatted dates
-   * We can use these to display the dates in a more user-friendly format
-   * @param {Object} data
-   */
-  addFormattedDates(data) {
-    Object.entries(data).forEach(val => _.map(data[val[0]].events, day => {
-      day.formattedDate = this.formattedDate(day.date);
-      return day;
-    }));
   }
 
   /**
@@ -108,7 +87,6 @@ module.exports = class BankHolidays {
       if (!this.checkDataIsValid(data)) {
         return Promise.reject(new Error('Failed to retrieve data from Bank Holidays API'));
       }
-      this.addFormattedDates(data);
 
       const fileName = `${__dirname}${BH_FILE_PATH}`;
       return await fs.writeFile(fileName, JSON.stringify(data, null, 2), { flag: 'w+' });

--- a/apps/viptt/models/bank-holidays.js
+++ b/apps/viptt/models/bank-holidays.js
@@ -3,10 +3,8 @@
 const _ = require('lodash');
 const Model = require('hof').model;
 const fs = require('fs/promises');
-const moment = require('moment');
 const config = require('../../../config');
 const inputDateFormat = config.inputDateFormat;
-const displayDateFormat = config.displayDateFormat;
 const bankHolidaysApi = config.bankHolidaysApi;
 
 const BH_FILE_PATH = '/../data/bank_hols_data.json';

--- a/apps/viptt/models/service-agreements.js
+++ b/apps/viptt/models/service-agreements.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const rawSLAData = require('../data/sla_data');
+
+const INSIDE_UK = 'inside-uk';
+const OUTSIDE_UK = 'outside-uk';
+const SLA_DEFAULT = 'default';
+
+/**
+ * Service agreement data model
+ * Contains data about the expected reply times for visa applications
+ * according to the service level agreements.
+ */
+module.exports = class ServiceAgreements {
+  /**
+   * Load the SLA data
+   * In future we may want to support having multiple different SLA versions
+   * for example if the SLA data changes after a certain date.
+   * @param {string} slaVersion
+   * @returns {Object}
+   */
+  constructor(slaVersion = SLA_DEFAULT) {
+    const slaData = JSON.parse(JSON.stringify(rawSLAData));
+    this._serviceAgreementData = slaData[slaVersion];
+  }
+
+  /**
+   * Return the SLA data according to the user's reason for applying
+   * and whether they are inside or outside the UK
+   * @param {string} reason
+   * @param {boolean} insideUK
+   * @returns {string | null}
+   */
+  getSLAData(reason, insideUK = true) {
+    const ukStatus = insideUK ? INSIDE_UK : OUTSIDE_UK;
+    return this._serviceAgreementData[ukStatus][reason] || null;
+  }
+};

--- a/apps/viptt/models/sla-calculator.js
+++ b/apps/viptt/models/sla-calculator.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const moment = require('moment');
+const config = require('../../../config');
+const inputDateFormat = config.inputDateFormat;
+
+/**
+ * SLA calculator
+ * This class is responsible for calculating the estimated reply date
+ * based on the input date and SLA days
+ */
+module.exports = class SLACalculator {
+  /**
+   * @param {BankHolidays} bankHolidays
+   */
+  constructor(bankHolidays) {
+    this._bankHolidays = bankHolidays;
+  }
+
+  /**
+   * @param {string} verificationDate
+   * @param {string} slaDays
+   * @returns {moment}
+   */
+  calculateReplyEstimate(verificationDate, slaDays) {
+    // convert input date into a moment object
+    const inputDate = moment(verificationDate, inputDateFormat);
+
+    // start date for application has to be on a working day. If input date is
+    // not a working day then it is moved forward to one to begin the calculation.
+    const startDate = this.goToNextWorkingDay(inputDate.clone());
+
+    // Add the SLA days to the start date
+    const replyDate = this.addWorkingDays(startDate.clone(), slaDays);
+
+    return replyDate;
+  }
+
+  /**
+   * Add working days until the specified number of working days have been added.
+   * If the added day is a non-working day (weekend or bank holiday),
+   * we keep adding days until we get to a working day.
+   * @param {moment} date
+   * @param {number} daysToAdd
+   * @returns {moment}
+   */
+  addWorkingDays(date, daysToAdd) {
+    let count = 0;
+    while (count < daysToAdd) {
+      // Move to next day
+      date.add(1, 'days');
+
+      // Only increment count if the next day is a working day
+      if (this._bankHolidays.isWorkingDay(date)) {
+        count++;
+      }
+    }
+    return date;
+  }
+
+  /**
+   * If date is either the weekend or bank holiday then move to the next working day.
+   * Note: this only moves the day forward if the supplied date is not a working day.
+   * @param {moment} date
+   * @returns {moment}
+   */
+  goToNextWorkingDay(date) {
+    if (!this._bankHolidays.isWorkingDay(date)) {
+      this.addWorkingDays(date, 1);
+    }
+    return date;
+  }
+
+  /**
+   * Check if we have passed the estimated reply date
+   * Reply date must be before or on same day as today
+   * @param {moment} replyDate
+   * @returns {boolean}
+   */
+  isWithinEstimate(replyDate, currentDate = moment()) {
+    return !currentDate.isAfter(replyDate, 'day');
+  }
+};

--- a/apps/viptt/translations/src/en/fields.json
+++ b/apps/viptt/translations/src/en/fields.json
@@ -75,5 +75,10 @@
         "label" : "Something else"
       }
     }
+  },
+  "identity-verification-date": {
+    "legend": "When did you verify your identity by providing your biometrics?",
+    "label": "When did you verify your identity by providing your biometrics?",
+    "hint": "For example, 01  12  2024"
   }
 }

--- a/apps/viptt/translations/src/en/validation.json
+++ b/apps/viptt/translations/src/en/validation.json
@@ -10,5 +10,10 @@
   },
   "why-did-you-apply-outside": {
     "required": "Select the reason you applied for a visa"
+  },
+  "identity-verification-date": {
+    "required": "Enter the date you provided your biometrics",
+    "date": "You must enter a real date",
+    "before": "The date cannot be in the future"
   }
 }

--- a/config.js
+++ b/config.js
@@ -4,14 +4,10 @@
 const env = process.env.NODE_ENV || 'production';
 
 module.exports = {
-  PRETTY_DATE_FORMAT: 'Do MMMM YYYY',
-  dateTimeFormat: 'DD MMM YYYY HH:mm:ss',
+  bankHolidaysApi: 'https://www.gov.uk/bank-holidays.json',
+  inputDateFormat: 'YYYY-MM-DD',
+  displayDateFormat: 'D MMMM YYYY',
   env: env,
-  email: {
-    notifyApiKey: process.env.NOTIFY_KEY,
-    notifyTemplate: process.env.NOTIFY_TEMPLATE,
-    caseWorker: process.env.CASEWORKER_EMAIL
-  },
   survey: {
     urls: {
       root: 'https://eforms.homeoffice.gov.uk/outreach/Feedback.ofml?FormName=coa/',
@@ -24,34 +20,5 @@ module.exports = {
   redis: {
     port: process.env.REDIS_PORT || '6379',
     host: process.env.REDIS_HOST || '127.0.0.1'
-  },
-  keycloak: {
-    token: process.env.KEYCLOAK_TOKEN_URL,
-    username: process.env.KEYCLOAK_USERNAME,
-    password: process.env.KEYCLOAK_PASSWORD,
-    clientId: process.env.KEYCLOAK_CLIENT_ID,
-    secret: process.env.KEYCLOAK_SECRET
-  },
-  upload: {
-    maxFileSizeInBytes: 25 * 1000 * 1000, // 25MB in bytes
-    hostname: process.env.FILE_VAULT_URL,
-    allowedMimeTypes: [
-      'image/png',
-      'image/jpg',
-      'image/jpeg',
-      'application/pdf',
-      'text/plain',
-      'text/html',
-      'application/vnd',
-      'message/rfc822',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.ms-powerpoint',
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      'application/rtf',
-      'text/csv',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/xml'
-    ]
   }
 };

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -4,6 +4,11 @@
   "behaviours": [
     "hof/components/clear-session"
   ],
+  "build": {
+    "watch": {
+      "ignore": ["apps/viptt/data"]
+    }
+  },
   "translations": "./apps/viptt/translations",
   "routes": [
     "./apps/viptt"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "busboy": "^1.6.0",
     "hof": "^22.4.1",
     "jquery": "^3.6.3",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "moment": "^2.30.1"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/server.js
+++ b/server.js
@@ -6,81 +6,109 @@ const busboy = require('busboy');
 const bl = require('bl');
 const logger = require('hof/lib/logger')({ env: config.env });
 let settings = require('./hof.settings');
+const BankHolidays = require('./apps/viptt/models/bank-holidays');
 
 settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require),
   routes: settings.routes.map(require)
 });
 
-const app = hof(settings);
 
-app.use((req, res, next) => {
-  res.locals.htmlLang = 'en';
-  res.locals.feedbackUrl = config.survey.urls.acq;
-  if (req.is('multipart/form-data')) {
-    try {
-      const bb = busboy({
-        headers: req.headers,
-        limits: {
-          fileSize: config.upload.maxFileSizeInBytes
-        }
-      });
-
-      bb.on('field', (key, value) => {
-        req.body[key] = value;
-      });
-
-      bb.on('file', (key, file, fileInfo) => {
-        file.pipe(bl((err, d) => {
-          if (err) {
-            logger.log('error', `Error processing file : ${err}`);
-            return;
-          }
-          if (!(d.length || fileInfo.filename)) {
-            logger.log('warn', 'Empty file received');
-            return;
-          }
-
-          const fileData = {
-            data: file.truncated ? null : d,
-            name: fileInfo.filename || null,
-            encoding: fileInfo.encoding,
-            mimetype: fileInfo.mimeType,
-            truncated: file.truncated,
-            size: file.truncated ? null : Buffer.byteLength(d, 'binary')
-          };
-
-          if (settings.multi) {
-            req.files[key] = req.files[key] || [];
-            req.files[key].push(fileData);
-          } else {
-            req.files[key] = fileData;
-          }
-        }));
-      });
-
-      let error;
-
-      bb.on('error', function (err) {
-        error = err;
-        next(err);
-      });
-
-      bb.on('finish', function () {
-        if (!error) {
-          next();
-        }
-      });
-      req.files = req.files || {};
-      req.body = req.body || {};
-      req.pipe(bb);
-    } catch (err) {
-      logger.log('error', `Error processing file: ${err}`);
-      next(err);
-    }
-  } else {
-    next();
+// overwrite bank holiday json once a day
+setInterval(() => {
+  try {
+    const bankHolidays = new BankHolidays();
+    bankHolidays.saveBankHolidays();
+  } catch (err) {
+    logger.log('error', `Error saving bank holidays : ${err}`);
   }
-});
+}, 1000 * 60 * 60 * 24);
 
-module.exports = app;
+
+const startApp = () => {
+  const app = hof(settings);
+
+  app.use((req, res, next) => {
+    res.locals.htmlLang = 'en';
+    res.locals.feedbackUrl = config.survey.urls.acq;
+    if (req.is('multipart/form-data')) {
+      try {
+        const bb = busboy({
+          headers: req.headers,
+          limits: {
+            fileSize: config.upload.maxFileSizeInBytes
+          }
+        });
+
+        bb.on('field', (key, value) => {
+          req.body[key] = value;
+        });
+
+        bb.on('file', (key, file, fileInfo) => {
+          file.pipe(bl((err, d) => {
+            if (err) {
+              logger.log('error', `Error processing file : ${err}`);
+              return;
+            }
+            if (!(d.length || fileInfo.filename)) {
+              logger.log('warn', 'Empty file received');
+              return;
+            }
+
+            const fileData = {
+              data: file.truncated ? null : d,
+              name: fileInfo.filename || null,
+              encoding: fileInfo.encoding,
+              mimetype: fileInfo.mimeType,
+              truncated: file.truncated,
+              size: file.truncated ? null : Buffer.byteLength(d, 'binary')
+            };
+
+            if (settings.multi) {
+              req.files[key] = req.files[key] || [];
+              req.files[key].push(fileData);
+            } else {
+              req.files[key] = fileData;
+            }
+          }));
+        });
+
+        let error;
+
+        bb.on('error', function (err) {
+          error = err;
+          next(err);
+        });
+
+        bb.on('finish', function () {
+          if (!error) {
+            next();
+          }
+        });
+        req.files = req.files || {};
+        req.body = req.body || {};
+        req.pipe(bb);
+      } catch (err) {
+        logger.log('error', `Error processing file: ${err}`);
+        next(err);
+      }
+    } else {
+      next();
+    }
+  });
+
+  module.exports = app;
+};
+
+// We'll overwrite bank holiday json with latest from API data
+// before starting the application
+const bankHolidays = new BankHolidays();
+
+bankHolidays.saveBankHolidays()
+  .then(startApp, err => {
+    // If we are unable to fetch bank hols data and save the file,
+    // then attempt to load an existing one.
+    // If we can load an existing file, then launch the app anyway.
+    logger.log('error', `Error saving bank holidays on app start : ${err}`);
+    bankHolidays.loadBankHolidays().then(startApp);
+  });

--- a/test/unit/bank-holidays.test.js
+++ b/test/unit/bank-holidays.test.js
@@ -1,0 +1,61 @@
+const moment = require('moment');
+const BankHolidays = require('../../apps/viptt/models/bank-holidays');
+const bankHols = require('./mock-data/mock_bank_hols_data');
+
+describe('BankHolidays', () => {
+  let bankHolidays;
+  const mockBankHolidaysData = JSON.parse(JSON.stringify(bankHols));
+
+  beforeEach(() => {
+    bankHolidays = new BankHolidays();
+    // Override the _bankHolidayData property with mock data
+    bankHolidays._bankHolidayData = mockBankHolidaysData;
+  });
+
+  describe('isBankHoliday', () => {
+    test('isBankHoliday returns true if date is a bank holiday', () => {
+      const testDate = moment('2025-08-25');
+      const result = bankHolidays.isBankHoliday(testDate);
+      expect(result).toBe(true);
+    });
+
+    test('isBankHoliday returns false if date is not a bank holiday', () => {
+      const testDate = moment('2025-08-24');
+      expect(bankHolidays.isBankHoliday(testDate)).toBe(false);
+    });
+  });
+
+  describe('isWeekend', () => {
+    test('isWeekend returns true if date is on a weekend', () => {
+      const testDate = moment('2025-05-10');
+      expect(bankHolidays.isWeekend(testDate)).toBe(true);
+    });
+
+    test('isWeekend returns false if date is not on a weekend', () => {
+      const testDate = moment('2025-05-09');
+      expect(bankHolidays.isWeekend(testDate)).toBe(false);
+    });
+
+    test('isWeekend returns false if date is a bank holiday but is not on a weekend', () => {
+      const testDate = moment('2025-05-05');
+      expect(bankHolidays.isWeekend(testDate)).toBe(false);
+    });
+  });
+
+  describe('isWorkingDay', () => {
+    test('isWorkingDay returns true if date is a work day', () => {
+      const testDate = moment('2025-05-09');
+      expect(bankHolidays.isWorkingDay(testDate)).toBe(true);
+    });
+
+    test('isWorkingDay returns false if date is a bank holiday', () => {
+      const testDate = moment('2025-05-05');
+      expect(bankHolidays.isWorkingDay(testDate)).toBe(false);
+    });
+
+    test('isWorkingDay returns false if date is on a weekend', () => {
+      const testDate = moment('2025-05-10');
+      expect(bankHolidays.isWorkingDay(testDate)).toBe(false);
+    });
+  });
+});

--- a/test/unit/bank-holidays.test.js
+++ b/test/unit/bank-holidays.test.js
@@ -7,7 +7,7 @@ const Model = require('hof/model');
 jest.mock('hof/model');
 
 const fs = require('fs/promises');
-jest.mock("fs/promises");
+jest.mock('fs/promises');
 
 describe('BankHolidays', () => {
   let bankHolidays;
@@ -16,7 +16,7 @@ describe('BankHolidays', () => {
   beforeEach(() => {
     bankHolidays = new BankHolidays();
     // Override the _bankHolidayData property with mock data
-    bankHolidays._bankHolidayData = mockBankHolidaysData['england-and-wales']['events'];
+    bankHolidays._bankHolidayData = mockBankHolidaysData['england-and-wales'].events;
   });
 
   describe('isBankHoliday', () => {

--- a/test/unit/check-sla-redirect.test.js
+++ b/test/unit/check-sla-redirect.test.js
@@ -1,0 +1,105 @@
+
+const moment = require('moment');
+const BankHolidays = require('../../apps/viptt/models/bank-holidays');
+const ServiceAgreements = require('../../apps/viptt/models/service-agreements');
+const SlaCalculator = require('../../apps/viptt/models/sla-calculator');
+const Behaviour = require('../../apps/viptt/behaviours/check-sla-redirect');
+const reqres = require('hof').utils.reqres;
+
+// Mock the required modules
+jest.mock('../../apps/viptt/models/bank-holidays');
+jest.mock('../../apps/viptt/models/service-agreements');
+jest.mock('../../apps/viptt/models/sla-calculator');
+
+// Mock required methods of ServiceAgreements
+ServiceAgreements.mockImplementation(() => {
+  return {
+    getSLAData: () => {
+      return {
+        weeks: '3',
+        days: '15'
+      };
+    }
+  };
+});
+
+describe('check-sla-redirect', () => {
+  test('Behaviour exports a function', () => {
+    expect(typeof Behaviour).toBe('function');
+  });
+
+  class Base {
+    successHandler() {}
+  }
+
+  let req;
+  let res;
+  let next;
+  let CheckSlaRedirect;
+  let instance;
+
+  beforeEach(() => {
+    BankHolidays.mockClear();
+    ServiceAgreements.mockClear();
+    SlaCalculator.mockClear();
+
+    req = reqres.req();
+    res = reqres.res();
+    next = jest.fn();
+
+    CheckSlaRedirect = Behaviour(Base);
+    instance = new CheckSlaRedirect();
+  });
+
+  describe('The \'successHandler\' method', () => {
+    const defaultSlaMock = {
+      calculateReplyEstimate: () => {
+        return moment('2025-05-09');
+      },
+      isWithinEstimate: () => false
+    };
+
+    beforeEach(() => {
+      SlaCalculator.mockImplementation(() => {
+        return defaultSlaMock;
+      });
+
+      Base.prototype.successHandler = jest.fn().mockReturnValue(req, res, next);
+      res.redirect = jest.fn(() => '/outcome-inside');
+      req.baseUrl = '';
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test('successHandler was called', async () => {
+      await instance.successHandler(req, res, next);
+      expect(Base.prototype.successHandler).toHaveBeenCalled();
+    });
+
+    test('calls res.redirect if date is within reply estimate', async () => {
+      SlaCalculator.mockImplementation(() => {
+        return {
+          ...defaultSlaMock,
+          isWithinEstimate: () => true
+        };
+      });
+
+      await instance.successHandler(req, res, next);
+      expect(res.redirect).toHaveBeenCalledWith('/outcome-inside');
+    });
+
+    test('does not call res.redirect if  date is not within reply estimate', async () => {
+      SlaCalculator.mockImplementation(() => {
+        return {
+          ...defaultSlaMock,
+          isWithinEstimate: () => false
+        };
+      });
+
+      await instance.successHandler(req, res, next);
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/mock-data/mock_bank_hols_data.json
+++ b/test/unit/mock-data/mock_bank_hols_data.json
@@ -1,58 +1,55 @@
-[
-  {
-    "title": "New Year’s Day",
-    "date": "2025-01-01",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "1 January 2025"
-  },
-  {
-    "title": "Good Friday",
-    "date": "2025-04-18",
-    "notes": "",
-    "bunting": false,
-    "formattedDate": "18 April 2025"
-  },
-  {
-    "title": "Easter Monday",
-    "date": "2025-04-21",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "21 April 2025"
-  },
-  {
-    "title": "Early May bank holiday",
-    "date": "2025-05-05",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "5 May 2025"
-  },
-  {
-    "title": "Spring bank holiday",
-    "date": "2025-05-26",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "26 May 2025"
-  },
-  {
-    "title": "Summer bank holiday",
-    "date": "2025-08-25",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "25 August 2025"
-  },
-  {
-    "title": "Christmas Day",
-    "date": "2025-12-25",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "25 December 2025"
-  },
-  {
-    "title": "Boxing Day",
-    "date": "2025-12-26",
-    "notes": "",
-    "bunting": true,
-    "formattedDate": "26 December 2025"
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      }
+    ]
   }
-]
+}

--- a/test/unit/mock-data/mock_bank_hols_data.json
+++ b/test/unit/mock-data/mock_bank_hols_data.json
@@ -1,0 +1,58 @@
+[
+  {
+    "title": "New Year’s Day",
+    "date": "2025-01-01",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "1 January 2025"
+  },
+  {
+    "title": "Good Friday",
+    "date": "2025-04-18",
+    "notes": "",
+    "bunting": false,
+    "formattedDate": "18 April 2025"
+  },
+  {
+    "title": "Easter Monday",
+    "date": "2025-04-21",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "21 April 2025"
+  },
+  {
+    "title": "Early May bank holiday",
+    "date": "2025-05-05",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "5 May 2025"
+  },
+  {
+    "title": "Spring bank holiday",
+    "date": "2025-05-26",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "26 May 2025"
+  },
+  {
+    "title": "Summer bank holiday",
+    "date": "2025-08-25",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "25 August 2025"
+  },
+  {
+    "title": "Christmas Day",
+    "date": "2025-12-25",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "25 December 2025"
+  },
+  {
+    "title": "Boxing Day",
+    "date": "2025-12-26",
+    "notes": "",
+    "bunting": true,
+    "formattedDate": "26 December 2025"
+  }
+]

--- a/test/unit/mock-data/mock_sla_data.json
+++ b/test/unit/mock-data/mock_sla_data.json
@@ -1,0 +1,64 @@
+{
+  "default": {
+    "inside-uk": {
+      "study-exam-or-school-exchange": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "visit-as-tourist-or-see-family": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "work-or-business-related-meetings": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "work-visa-health-and-care": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "lecture-research-or-academic-placement": {
+        "weeks": "8",
+        "days": "40"
+      },
+      "bno-with-connections-to-hk": {
+        "weeks": "12",
+        "days": "60"
+      }
+    },
+    "outside-uk": {
+      "study-exam-or-school-exchange": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "visit-as-tourist-or-see-family": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "work-or-business-related-meetings": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "lecture-research-or-academic-placement": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "get-married-or-civil-partnership": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "have-medical-treatment": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "travel-through-uk-to-another-country": {
+        "weeks": "3",
+        "days": "15"
+      },
+      "bno-with-connections-to-hk": {
+        "weeks": "12",
+        "days": "60"
+      }
+    }
+  }
+}

--- a/test/unit/service-agreements.test.js
+++ b/test/unit/service-agreements.test.js
@@ -1,0 +1,39 @@
+const ServiceAgreements = require('../../apps/viptt/models/service-agreements');
+const slaData = require('./mock-data/mock_sla_data');
+
+describe('ServiceAgreements', () => {
+  let serviceAgreements;
+  const mockSLAData = JSON.parse(JSON.stringify(slaData));
+
+  beforeEach(() => {
+    serviceAgreements = new ServiceAgreements();
+    // Override the _serviceAgreementData property with mock data
+    serviceAgreements._serviceAgreementData = mockSLAData.default;
+  });
+
+  describe('getSLAData', () => {
+    test('getSLAData returns correct sla data from a given reason inside UK', () => {
+      const reason = 'visit-as-tourist-or-see-family';
+      const insideUK = true;
+      expect(serviceAgreements.getSLAData(reason, insideUK)).toEqual({
+        weeks: '8',
+        days: '40'
+      });
+    });
+
+    test('getSLAData returns correct sla data from a given reason outside UK', () => {
+      const reason = 'visit-as-tourist-or-see-family';
+      const insideUK = false;
+      expect(serviceAgreements.getSLAData(reason, insideUK)).toEqual({
+        weeks: '3',
+        days: '15'
+      });
+    });
+
+    test('getSLAData returns null if reason cannot be found', () => {
+      const reason = 'this-is-a-test';
+      const insideUK = false;
+      expect(serviceAgreements.getSLAData(reason, insideUK)).toBe(null);
+    });
+  });
+});

--- a/test/unit/sla-calculator.test.js
+++ b/test/unit/sla-calculator.test.js
@@ -1,0 +1,134 @@
+const moment = require('moment');
+const BankHolidays = require('../../apps/viptt/models/bank-holidays');
+const bankHols = require('./mock-data/mock_bank_hols_data');
+const SlaCalculator = require('../../apps/viptt/models/sla-calculator');
+const { displayDateFormat } = require('../../config');
+
+describe('SlaCalculator', () => {
+  let bankHolidays;
+  const mockBankHolidaysData = JSON.parse(JSON.stringify(bankHols));
+
+  let slaCalculator;
+
+  beforeEach(() => {
+    // Create bank holidays needed by sla calculator
+    bankHolidays = new BankHolidays();
+
+    // Override the _bankHolidayData property with mock data
+    bankHolidays._bankHolidayData = mockBankHolidaysData;
+
+    // Sla calculator that we will test
+    slaCalculator = new SlaCalculator(bankHolidays);
+  });
+
+  describe('calculateReplyEstimate', () => {
+    test('calculateReplyEstimate returns correct estimated reply date', () => {
+      const verificationDate = '2025-04-15';
+      const slaDays = 15;
+
+      // Should land on Friday 9th May 2025
+      const estimatedReplyDate = slaCalculator.calculateReplyEstimate(
+        verificationDate,
+        slaDays
+      );
+      expect(estimatedReplyDate.format(displayDateFormat)).toBe('9 May 2025');
+    });
+
+    test('calculateReplyEstimate return the next working day if sla estimate ends on a weekend', () => {
+      const verificationDate = '2025-04-15';
+      const slaDays = 16;
+
+      // Should land on Monday 12th May 2025
+      const estimatedReplyDate = slaCalculator.calculateReplyEstimate(
+        verificationDate,
+        slaDays
+      );
+      expect(estimatedReplyDate.format(displayDateFormat)).toBe('12 May 2025');
+    });
+
+    test('calculateReplyEstimate return the next working day if sla estimate ends on a bank holiday', () => {
+      const verificationDate = '2025-04-10';
+      const slaDays = 15;
+
+      // Should land on Monday 6th May 2025
+      const estimatedReplyDate = slaCalculator.calculateReplyEstimate(
+        verificationDate,
+        slaDays
+      );
+      expect(estimatedReplyDate.format(displayDateFormat)).toBe('6 May 2025');
+    });
+  });
+
+  describe('addWorkingDays', () => {
+    test('addWorkingDays adds days excluding bank holidays and weekends (test 1)', () => {
+      const testDate = moment('2025-04-15');
+      const daysToAdd = 5;
+      const newDate = slaCalculator.addWorkingDays(testDate, daysToAdd);
+      expect(newDate.format(displayDateFormat)).toBe('24 April 2025');
+    });
+
+    test('addWorkingDays adds days excluding bank holidays and weekends (test 2)', () => {
+      const testDate = moment('2025-04-15');
+      const daysToAdd = 6;
+      const newDate = slaCalculator.addWorkingDays(testDate, daysToAdd);
+      expect(newDate.format(displayDateFormat)).toBe('25 April 2025');
+    });
+
+    test('addWorkingDays returns same day when zero days are added', () => {
+      const testDate = moment('2025-04-15');
+      const daysToAdd = 0;
+      const newDate = slaCalculator.addWorkingDays(testDate, daysToAdd);
+      expect(newDate.format(displayDateFormat)).toBe('15 April 2025');
+    });
+
+    test('addWorkingDays returns same day when negative days are added', () => {
+      const testDate = moment('2025-04-15');
+      const daysToAdd = -5;
+      const newDate = slaCalculator.addWorkingDays(testDate, daysToAdd);
+      expect(newDate.format(displayDateFormat)).toBe('15 April 2025');
+    });
+  });
+
+  describe('goToNextWorkingDay', () => {
+    test('goToNextWorkingDay stays on same day if not a weekend or bank holiday', () => {
+      const testDate = moment('2025-04-15');
+      const newDate = slaCalculator.goToNextWorkingDay(testDate);
+      expect(newDate.format(displayDateFormat)).toBe('15 April 2025');
+    });
+
+    test('goToNextWorkingDay advances day if it is a weekend', () => {
+      const testDate = moment('2025-04-12');
+      const newDate = slaCalculator.goToNextWorkingDay(testDate);
+      expect(newDate.format(displayDateFormat)).toBe('14 April 2025');
+    });
+
+    test('goToNextWorkingDay advances day if it is a bank holiday', () => {
+      const testDate = moment('2025-04-21');
+      const newDate = slaCalculator.goToNextWorkingDay(testDate);
+      expect(newDate.format(displayDateFormat)).toBe('22 April 2025');
+    });
+  });
+
+  describe('isWithinEstimate', () => {
+    test('isWithinEstimate returns true if current date is before reply date', () => {
+      const currentDate = moment('2025-04-12');
+      const replyDate = moment('2025-04-15');
+      const isWithin = slaCalculator.isWithinEstimate(replyDate, currentDate);
+      expect(isWithin).toBe(true);
+    });
+
+    test('isWithinEstimate returns true if current date is the same as reply date', () => {
+      const currentDate = moment('2025-04-15');
+      const replyDate = moment('2025-04-15');
+      const isWithin = slaCalculator.isWithinEstimate(replyDate, currentDate);
+      expect(isWithin).toBe(true);
+    });
+
+    test('isWithinEstimate returns false if current date is after reply date', () => {
+      const currentDate = moment('2025-04-16');
+      const replyDate = moment('2025-04-15');
+      const isWithin = slaCalculator.isWithinEstimate(replyDate, currentDate);
+      expect(isWithin).toBe(false);
+    });
+  });
+});

--- a/test/unit/sla-calculator.test.js
+++ b/test/unit/sla-calculator.test.js
@@ -15,7 +15,7 @@ describe('SlaCalculator', () => {
     bankHolidays = new BankHolidays();
 
     // Override the _bankHolidayData property with mock data
-    bankHolidays._bankHolidayData = mockBankHolidaysData;
+    bankHolidays._bankHolidayData = mockBankHolidaysData['england-and-wales']['events'];
 
     // Sla calculator that we will test
     slaCalculator = new SlaCalculator(bankHolidays);

--- a/test/unit/sla-calculator.test.js
+++ b/test/unit/sla-calculator.test.js
@@ -15,7 +15,7 @@ describe('SlaCalculator', () => {
     bankHolidays = new BankHolidays();
 
     // Override the _bankHolidayData property with mock data
-    bankHolidays._bankHolidayData = mockBankHolidaysData['england-and-wales']['events'];
+    bankHolidays._bankHolidayData = mockBankHolidaysData['england-and-wales'].events;
 
     // Sla calculator that we will test
     slaCalculator = new SlaCalculator(bankHolidays);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4773,7 +4773,7 @@ module-deps@^6.2.3:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-moment@^2.29.4:
+moment@^2.29.4, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==


### PR DESCRIPTION
## What? 
Add verification date input and logic to calculate estimated reply according to SLA and redirect accordingly

## Why? 
Requested changes for [https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-31](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-31)

## How? 
* Add verification date field to biometrics page
* Add models for bank holiday data and SLA data
* Add behaviour to calculate the estimated reply date
* Redirect to correct page according to calculation result
* Add unit tests

## Testing?
Unit tests added

## Screenshots (optional)
![VIPTT-31](https://github.com/user-attachments/assets/62daed80-f363-41b4-9519-c4ec2d3ca760)
![VIPTT-31-Error](https://github.com/user-attachments/assets/64c1eba4-7536-45b3-9585-2d30d7f0a26e)


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging