### PR TITLE
VIPTT-25 Add outcome page (inside SLA)

### DIFF
--- a/apps/viptt/behaviours/check-sla-redirect.js
+++ b/apps/viptt/behaviours/check-sla-redirect.js
@@ -1,6 +1,8 @@
+const moment = require('moment');
 const SlaCalculator = require('../models/sla-calculator');
 const BankHolidays = require('../models/bank-holidays');
 const ServiceAgreements = require('../models/service-agreements');
+const { displayDateFormat, inputDateFormat } = require('../../../config');
 /**
  * Check if the user's expected visa reply date is within SLA
  * and redirect to correct page if this is true.
@@ -15,7 +17,7 @@ module.exports = superclass =>
       // SLA model
       this._serviceAgreements = new ServiceAgreements();
 
-      // Sla calculation helper
+      // SLA calculation helper
       this._slaCalculator = new SlaCalculator(this._bankHolidays);
 
       // Get the user's reason for applying depending on
@@ -36,6 +38,12 @@ module.exports = superclass =>
         verificationDate,
         slaData.days
       );
+
+      // Add values that are needed to display in the outcome page
+      const formattedInputDate = moment(verificationDate, inputDateFormat).format(displayDateFormat);
+      req.sessionModel.set('application-start-date', formattedInputDate);
+      req.sessionModel.set('estimated-reply-date', estimatedReplyDate.format(displayDateFormat));
+      req.sessionModel.set('sla-weeks', slaData.weeks);
 
       // Check if reply is still within the SLA timeline
       const insideSLA = this._slaCalculator.isWithinEstimate(estimatedReplyDate);

--- a/apps/viptt/translations/src/en/pages.json
+++ b/apps/viptt/translations/src/en/pages.json
@@ -1,20 +1,4 @@
 {
-  "confirm": {
-    "header": "Check your answers",
-    "submit-warning": "Once you have submitted your application, you will not be able to adjust it. Please check it is correct.",
-    "sections": {
-      "name": {
-        "header": "Personal Details"
-      }
-    }
-  },
-  "complete": {
-    "header": "You submission have been sent",
-    "content-copy-sent": "We have sent you a confirmation email",
-    "content-whats-next": "What happens next",
-    "content-respond-1": "This is a test paragraph",
-    "content-feedback-link-text": "What do you think of this service?"
-  },
   "work-visa-types-inside-uk": {
     "header": "Did you apply for a Health and Care Worker visa?",
     "paragraph": "A <a href='https://www.gov.uk/get-access-evisa'>Health and Care Worker</a> visa allows medical professionals to do an eligible job with the NHS, an NHS supplier or in adult social care."
@@ -30,5 +14,26 @@
     "intro-p6": "to stay under the Homes for Ukraine scheme",
     "intro-p7": "to stay under a family reunion scheme",
     "paragraph": "If you applied for one of these, please <a href='https://www.gov.uk/government/collections/visa-processing-times'>check standard visa processing times.</a>"
+  },
+  "outcome-inside": {
+    "expected-reply": "You can expect a reply by {{values.estimated-reply-date}}",
+    "explanation": "This date is based on the standard processing time of {{values.sla-weeks}} weeks from {{values.application-start-date}}.",
+    "heading-1": "More information",
+    "paragraph-1": "We are currently processing your application.",
+    "warning": "Warning",
+    "warning-paragraph-1": "Please do not contact us until after {{values.estimated-reply-date}}.",
+    "warning-paragraph-2": "We will contact you if we need more information.",
+    "paragraph-2": "Processing times are based on the UK working week (Monday to Friday). They do not include public holidays in the UK or other countries.",
+    "heading-2": "What happens next",
+    "paragraph-3": "Visa processing times are based on the date you provided your biometrics.",
+    "paragraph-4": "We will contact you:",
+    "bullet-1": "if we have questions or need more information",
+    "bullet-2": "if your application is going to take longer than the standard processing time",
+    "bullet-3": "when we have made a decision",
+    "paragraph-5": "Please check your email regularly for updates, including your spam or junk folder.",
+    "paragraph-6": "If you asked to be contacted by letter, please check your post.",
+    "paragraph-7": "If you've finished, you can",
+    "link": "https://homeoffice.eu.qualtrics.com/jfe/form/SV_9Qrx3WHZAYtpTj8?Source=ISLASubmissionPage",
+    "link-text": "leave feedback (opens in a new tab)"
   }
 }

--- a/apps/viptt/views/outcome-inside.html
+++ b/apps/viptt/views/outcome-inside.html
@@ -1,0 +1,41 @@
+{{<partials-page}}
+  {{$page-content}}
+  <div class="govuk-panel govuk-panel--confirmation">
+    <h1 class="govuk-panel__title">
+      {{#t}}pages.outcome-inside.expected-reply{{/t}}
+    </h1>
+  </div>
+  <p>{{#t}}pages.outcome-inside.explanation{{/t}}</p>
+
+  <h2 class="govuk-heading-m">{{#t}}pages.outcome-inside.heading-1{{/t}}</h2>
+  <p>{{#t}}pages.outcome-inside.paragraph-1{{/t}}</p>
+
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-visually-hidden">{{#t}}pages.outcome-inside.warning{{/t}}</span>
+      {{#t}}pages.outcome-inside.warning-paragraph-1{{/t}}
+      <br>
+      {{#t}}pages.outcome-inside.warning-paragraph-2{{/t}}
+    </strong>
+  </div>
+
+  <p>{{#t}}pages.outcome-inside.paragraph-2{{/t}}</p>
+  <h2 class="govuk-heading-m">{{#t}}pages.outcome-inside.heading-2{{/t}}</h2>
+  <p>{{#t}}pages.outcome-inside.paragraph-3{{/t}}</p>
+  <p>{{#t}}pages.outcome-inside.paragraph-4{{/t}}</p>
+  <ul>
+    <li>{{#t}}pages.outcome-inside.bullet-1{{/t}}</li>
+    <li>{{#t}}pages.outcome-inside.bullet-2{{/t}}</li>
+    <li>{{#t}}pages.outcome-inside.bullet-3{{/t}}</li>
+  </ul>
+  <p>{{#t}}pages.outcome-inside.paragraph-5{{/t}}</p>
+  <p>{{#t}}pages.outcome-inside.paragraph-6{{/t}}</p>
+  <div class="govuk-inset-text">
+    <p>
+      {{#t}}pages.outcome-inside.paragraph-7{{/t}}
+      <a href="{{#t}}pages.outcome-inside.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.outcome-inside.link-text{{/t}}</a>.
+    </p>
+  </div>
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -293,6 +293,10 @@ textarea {
   margin-bottom: 0.5rem;
 }
 
+.govuk-warning-text__icon {
+  margin-top: 7px;
+}
+
 pre.looped-records {
   white-space: pre-wrap;
   word-wrap: break-word;


### PR DESCRIPTION
## What?
Add outcome page for inside SLA result

## Why? 
Business requirement for [VIPTT-25](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-25)

## How? 
* Add html for new page
* update behaviour to save the data for outome page
* Add translations https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-25

## Testing?
No tests as only standard HOF functionality

## Screenshots (optional)
![VIPTT-25](https://github.com/user-attachments/assets/99d49a18-873c-4ff9-acd1-10fb40c673f6)

## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
