### PR TITLE
VIPTT-47 Use correct SLA data for health visa

### DIFF
--- a/apps/viptt/behaviours/check-sla-redirect.js
+++ b/apps/viptt/behaviours/check-sla-redirect.js
@@ -23,9 +23,20 @@ module.exports = superclass =>
       // Get the user's reason for applying depending on
       // whether they were inside or outside UK.
       const insideUK = req.sessionModel.get('were-you-in-uk') === 'yes';
-      const reasonForApplying = insideUK ?
+      let reasonForApplying = insideUK ?
         req.sessionModel.get('why-did-you-apply-inside') :
         req.sessionModel.get('why-did-you-apply-outside');
+
+      // Special case for health care worker visa:
+      // Check if the user has applied for a work visa while inside UK
+      if (insideUK && reasonForApplying === 'work-or-business-related-meetings') {
+        // Check if the user has selected the health care worker visa option
+        const appliedForHealthCareVisa = req.sessionModel.get('health-care-worker-visa');
+        if(appliedForHealthCareVisa === 'yes') {
+          // Override the reason for applying to health and care visa
+          reasonForApplying = 'work-visa-health-and-care';
+        }
+      }
 
       // Retrieve the correct sla data
       const slaData = this._serviceAgreements.getSLAData(reasonForApplying, insideUK);


### PR DESCRIPTION
## What? 
Bug fix for [VIPTT-47](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-47)

## Why? 
Outcome page is not showing correct SLA weeks when user has applied for a health worker visa

## How? 
* Update the behaviour on the biometrics page
* Check for the scenario where the user is applying for a health worker visa
* Update reason for applying that we use to get SLA data 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
