### PR TITLE
VIPTT-46 Update validation for biometric page

### DIFF
--- a/apps/viptt/fields/index.js
+++ b/apps/viptt/fields/index.js
@@ -53,6 +53,10 @@ module.exports = {
   'identity-verification-date': dateComponent('identity-verification-date', {
     mixin: 'input-date',
     isPageHeading: true,
-    validate: ['required', 'before']
+    validate: [
+      'required',
+      'before', //  Date must not be in the future
+      { type: 'after', arguments: ['1', 'years'] } // Date must not be more than 1 year in the past
+    ]
   })
 };

--- a/apps/viptt/translations/src/en/validation.json
+++ b/apps/viptt/translations/src/en/validation.json
@@ -14,6 +14,7 @@
   "identity-verification-date": {
     "required": "Enter the date you provided your biometrics",
     "date": "You must enter a real date",
-    "before": "The date cannot be in the future"
+    "before": "The date cannot be in the future",
+    "after": "The date you enter must not be more than 12 months in the past"
   }
 }


### PR DESCRIPTION
## What?
[VIPTT-46](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-46) update validation for biometric page

## Why?
Business requirement: Validation for verification date field must not allow user to add a date more than one year in the past

## How? 
* Update validation for the date biometric field
* Ensure validation date cannot be more than one year in the past
* Add new error message https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-46

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
