### PR TITLE
VIPTT-52 fix incorrect link bug

### DIFF
--- a/apps/viptt/translations/src/en/pages.json
+++ b/apps/viptt/translations/src/en/pages.json
@@ -1,7 +1,7 @@
 {
   "work-visa-types-inside-uk": {
     "header": "Did you apply for a Health and Care Worker visa?",
-    "paragraph": "A <a href='https://www.gov.uk/get-access-evisa'>Health and Care Worker</a> visa allows medical professionals to do an eligible job with the NHS, an NHS supplier or in adult social care."
+    "paragraph": "A <a href='https://www.gov.uk/health-care-worker-visa'>Health and Care Worker</a> visa allows medical professionals to do an eligible job with the NHS, an NHS supplier or in adult social care."
   },
   "out-of-scope": {
     "header": "Family visas and applications to settle in the UK",


### PR DESCRIPTION
## What? 
[VIPTT-52][(https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-52](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-52) - Fix incorrect link for VIPTT

## Why? 
Allows user to get the correct information when clicking the link

## How? 


## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging