### PR TITLE
VIPTT-51 fix font for heading

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -316,3 +316,7 @@ a {
   @extend .govuk-link;
 }
 
+// Fix for headings not using Transport font
+.heading-large, h1 {
+    font-family: "GDS Transport", arial, sans-serif;
+}


### PR DESCRIPTION
## What? 
Fix for font not displaying correctly

## Why? 
Bug fix: 
[/VIPTT-51](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-51)

## How? 
Override heading css to use GDS Transport

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
