### PR TITLE
VIPTT-56 Change example date

### DIFF
--- a/apps/viptt/translations/src/en/fields.json
+++ b/apps/viptt/translations/src/en/fields.json
@@ -79,6 +79,6 @@
   "identity-verification-date": {
     "legend": "When did you verify your identity by providing your biometrics?",
     "label": "When did you verify your identity by providing your biometrics?",
-    "hint": "For example, 01  12  2024"
+    "hint": "For example, 31 05 2025"
   }
 }


### PR DESCRIPTION
## What?
Update the example date used for biometric field

## Why?
Change request: [VIPTT-56](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-56)

## How? 
Update translation json

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
