### PR TITLE
VIPTT-60-fix-outcomes-title

### DIFF
--- a/apps/viptt/translations/src/en/pages.json
+++ b/apps/viptt/translations/src/en/pages.json
@@ -9,6 +9,7 @@
     "paragraph": "You can <a href='https://www.gov.uk/government/collections/visa-processing-times'>check standard visa processing times</a> to find out how long it usually takes to get a decision on a family or settlement application."
   },
   "outcome-inside": {
+    "title": "Outcome",
     "expected-reply": "You can expect a reply by {{values.estimated-reply-date}}",
     "explanation": "This date is based on the standard processing time of {{values.sla-weeks}} weeks from {{values.application-start-date}}.",
     "heading-1": "More information",
@@ -30,6 +31,7 @@
     "link-text": "leave feedback (opens in a new tab)"
   },
   "outcome-outside": {
+    "title": "Outcome",
     "expected-reply": "You should have received a reply by {{values.estimated-reply-date}}",
     "explanation": "This date is based on the standard processing time of {{values.sla-weeks}} weeks from {{values.application-start-date}}.",
     "heading-1": "More information",


### PR DESCRIPTION
## What? 
Fix for extra hyphen showing in title
## Why? 
Bug fix [VIPTT-60](https://collaboration.homeoffice.gov.uk/jira/browse/VIPTT-60)
## How? 
Update page title text 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
