### PR TITLE
VIPTT-116-Added PV to the service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,11 @@ environment:
   STG_ENV: sas-viptt-stg
   UAT_ENV: sas-viptt-uat
   BRANCH_ENV: sas-viptt-branch
+  REDIS_PERSISTENCE_ENABLED: "true"
+  REDIS_PERSISTENCE_ACCESS_MODES: ReadWriteOnce
+  REDIS_PERSISTENCE_STORAGE_CLASS: gp2-encrypted-eu-west-2b
+  REDIS_PERSISTENCE_EXISTING_CLAIM: ""
+  REDIS_PERSISTENCE_ANNOTATIONS_FILE: ""
   PRODUCTION_URL: www.check-your-visa-processing-time.homeoffice.gov.uk
   IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/viptt

--- a/bin/clean_up.sh
+++ b/bin/clean_up.sh
@@ -10,6 +10,7 @@ export kubectl="kubectl --insecure-skip-tls-verify --server=$KUBE_SERVER --names
 $kubectl delete --all deploy
 $kubectl delete --all svc
 $kubectl delete --all ing
+$kubectl delete --all pvc
 
 for each in $($kubectl get netpol -o jsonpath="{.items[*].metadata.name}");
 do

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,6 +5,14 @@ export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yam
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
+redis_storage_files='kube/redis/redis-persistent-volume.yml'
+redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+
+export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-"false"}
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-"ReadWriteOnce"}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-""}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-""}
+export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-""}
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
@@ -21,23 +29,36 @@ fi
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
+if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_SIZE=5Gi
+else
+  export REDIS_PERSISTENCE_SIZE=1Gi
+fi
+
+if [[ ${REDIS_PERSISTENCE_ENABLED} == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+  $kd -f $redis_storage_files
+fi
+
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/app
+  $kd -f $redis_runtime_files
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  $kd -f $redis_runtime_files
+  $kd -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis
+  $kd -f $redis_runtime_files
   $kd -f kube/app
 
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  $kd -f $redis_runtime_files
+  $kd -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -29,6 +29,9 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 994
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: redis
           # redis:v7.0.15
@@ -48,5 +51,19 @@ spec:
               cpu: "100m"
               memory: "200Mi"
       volumes:
+        {{ if and (eq .REDIS_PERSISTENCE_ENABLED "true") (ne .REDIS_PERSISTENCE_EXISTING_CLAIM "") }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+        {{ else if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+        - name: data
+          persistentVolumeClaim:
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-pvc
+            {{ end }}
+        {{ else }}
         - name: data
           emptyDir: {}
+        {{ end }}

--- a/kube/redis/redis-persistent-volume.yml
+++ b/kube/redis/redis-persistent-volume.yml
@@ -1,0 +1,23 @@
+{{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-pvc
+  {{ end }}
+  {{ if ne .REDIS_PERSISTENCE_ANNOTATIONS_FILE "" }}
+  annotations:
+{{ file .REDIS_PERSISTENCE_ANNOTATIONS_FILE | indent 4 }}
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  {{ if and (ne .REDIS_PERSISTENCE_STORAGE_CLASS "") (ne .REDIS_PERSISTENCE_STORAGE_CLASS "null") }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  {{ end }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}
+{{ end }}


### PR DESCRIPTION
## What? 
This pull request adds support for persistent storage for Redis deployments in Kubernetes, replacing ephemeral storage with persistent volumes and claims. It introduces new configuration files for `PersistentVolume` and `PersistentVolumeClaim` resources, and updates the Redis deployment to use these resources. The configuration is dynamic, supporting different environments (production, branch, etc.) with conditional naming and storage sizes.

Persistent storage support for Redis:

* Added `redis-persistent-volume.yml` to define a `PersistentVolume` with conditional naming and storage size based on the environment.
* Added `redis-persistent-volume-claim.yml` to define a `PersistentVolumeClaim` with conditional naming, storage class, and volume binding, supporting different sizes for production and non-production environments.
* Updated `redis-deployment.yml` to use a `persistentVolumeClaim` for the Redis data volume instead of an `emptyDir`, with claim names set dynamically based on the environment.
## Why? 
PersistentVolume ensures that data (like Redis cache/session state) survives pod restarts, rescheduling, or crashes — without it, everything stored in the container is lost the moment it stops running.

## How? 
Config changes

## Testing?
Restart pods and observe behaviour

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
